### PR TITLE
Derive SND_PCI_QUIRK values from /sys/class values of running system

### DIFF
--- a/setup_snd-hda-codec-realtek.sh
+++ b/setup_snd-hda-codec-realtek.sh
@@ -16,8 +16,17 @@ DKMS_MODULE_VERSION='0.1'
 
 "${BIN_ABSPATH}/dkms-module_create.sh" "${KERNEL_MODULE_NAME}" "${DKMS_MODULE_VERSION}"
 
+# generate the patch based on the system running
+if read PRODUCT < /sys/devices/virtual/dmi/id/product_name &&
+   read ID < /sys/class/sound/hwC0D0/subsystem_id &&
+   ID1=$(printf "0x%04x" $(( ID >> 16 & 0xffff ))) &&
+   ID2=$(printf "0x%04x" $(( ID & 0xffff )))
+then PLINE="SND_PCI_QUIRK($ID1, $ID2, "'"'"$PRODUCT"'"'", ALC287_FIXUP_CS35L41_I2C_2),"
+else PLINE='SND_PCI_QUIRK(0x103c, 0x8a29, "HP Envy x360 15-ew0xxx", ALC287_FIXUP_CS35L41_I2C_2),'
+fi
+
 # create the patch file to apply to the source of the snd-hda-codec-realtek kernel module
-sudo tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/patch_realtek.patch" <<'EOF'
+sudo tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/patch_realtek.patch" <<EOF
 --- sound/pci/hda/patch_realtek.c.orig
 +++ sound/pci/hda/patch_realtek.c
 @@ -9452,12 +9452,13 @@
@@ -27,7 +36,7 @@ sudo tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/patch_realtek.pa
 +  SND_PCI_QUIRK(0x103c, 0x8a78, "HP Dev One", ALC285_FIXUP_HP_LIMIT_INT_MIC_BOOST),
  	SND_PCI_QUIRK(0x103c, 0x8a78, "HP Dev One", ALC285_FIXUP_HP_LIMIT_INT_MIC_BOOST),
 -	SND_PCI_QUIRK(0x103c, 0x8aa0, "HP ProBook 440 G9 (MB 8A9E)", ALC236_FIXUP_HP_GPIO_LED),
-+	SND_PCI_QUIRK(0x103c, 0x8a29, "HP Envy x360 15-ew0xxx", ALC287_FIXUP_CS35L41_I2C_2),
++	$PLINE
  	SND_PCI_QUIRK(0x103c, 0x8aa3, "HP ProBook 450 G9 (MB 8AA1)", ALC236_FIXUP_HP_GPIO_LED),
  	SND_PCI_QUIRK(0x103c, 0x8aa8, "HP EliteBook 640 G9 (MB 8AA6)", ALC236_FIXUP_HP_GPIO_LED),
  	SND_PCI_QUIRK(0x103c, 0x8aab, "HP EliteBook 650 G9 (MB 8AA9)", ALC236_FIXUP_HP_GPIO_LED),


### PR DESCRIPTION
Something like this may make the patching process easier as the quirk values are computed to suit their running hardware