### PR TITLE
Support pure Debian as well as Debian based distros

### DIFF
--- a/dkms-module_build.sh
+++ b/dkms-module_build.sh
@@ -18,7 +18,7 @@ dkms build -k "${KERNEL_VERSION}" -m "${KERNEL_MODULE_NAME}" -v "${DKMS_MODULE_V
 dkms install -k "${KERNEL_VERSION}" -m "${KERNEL_MODULE_NAME}" -v "${DKMS_MODULE_VERSION}" --force
 
 if dmesg | grep -q 'initramfs'; then
-  if grep -q "^ID_LIKE=debian" /etc/os-release; then
+  if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
     update-initramfs -u -k "${KERNEL_VERSION}"
   elif grep -q "^ID=arch" /etc/os-release; then
     mkinitcpio -P

--- a/dkms-module_create.sh
+++ b/dkms-module_create.sh
@@ -15,7 +15,7 @@ DKMS_MODULE_VERSION="${2}"
 # check OS prerequisites --------------------------------------------------------------------------
 
 # perform OS-specific preparation steps
-if grep -q "^ID_LIKE=debian" /etc/os-release; then
+if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
   apt install build-essential dkms dwarves
 
   if grep -q "^ID=ubuntu" /etc/os-release && [ -e "/usr/lib/modules/$(uname -r)/build" ]; then
@@ -27,7 +27,7 @@ else
 fi
 
 # install linux-headers package if not present 
-if grep -q "^ID_LIKE=debian" /etc/os-release; then
+if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
   HEADERS_PACKAGE_NAME="linux-headers-${KERNEL_VERSION}"
 
   if ! dpkg -l | grep -q $HEADERS_PACKAGE_NAME; then

--- a/kernel-version_get.sh
+++ b/kernel-version_get.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "${KERNEL_VERSION}" ]; then
-  if grep -q "^ID_LIKE=debian" /etc/os-release; then
+  if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
     LATEST_LINUX_IMAGE_PACKAGE=$( dpkg -l | grep -oP 'linux-image-\d\S*\b' | sort -r | head -n1 )
     KERNEL_VERSION=${LATEST_LINUX_IMAGE_PACKAGE#linux-image-}
   elif grep -q "^ID=fedora" /etc/os-release; then
@@ -23,7 +23,7 @@ SOURCE_MINOR_VERSION="${SOURCE_MINOR_VERSION%%.*}"
 SOURCE_SUB_VERSION="${KERNEL_VERSION##*.}"
 SOURCE_SUB_VERSION="${SOURCE_SUB_VERSION%%-*}"
 
-if grep -q "^ID_LIKE=debian" /etc/os-release && [ -z "${SOURCE_SUB_VERSION}" ] && [ -e "/usr/src/linux-headers-${KERNEL_VERSION}/Makefile" ]; then
+if grep -qE "^ID(_LIKE)?=debian" /etc/os-release && [ -z "${SOURCE_SUB_VERSION}" ] && [ -e "/usr/src/linux-headers-${KERNEL_VERSION}/Makefile" ]; then
   makefile="/usr/src/linux-headers-${KERNEL_VERSION}/Makefile"
   if [ "$(wc -l < $makefile)" -eq 1 ] && grep -q "^include " $makefile ; then
     makefile=$(tr -s " " < $makefile | cut -d " " -f 2)


### PR DESCRIPTION
In Debian `/etc/os-release` does not contain `ID_LIKE=`, but `ID=`; therefore change checks to both for debian/debian-based code