### PR TITLE
Update setup_snd-hda-scodec-cs35l41.sh to support Kernel 6.6

### DIFF
--- a/setup_snd-hda-scodec-cs35l41.sh
+++ b/setup_snd-hda-scodec-cs35l41.sh
@@ -20,10 +20,10 @@ fi
 "${BIN_ABSPATH}/dkms-module_create.sh" "${KERNEL_MODULE_NAME}" "${DKMS_MODULE_VERSION}"
 
 # create the patch file to apply to the source of the snd-hda-scodec-cs35l41 kernel module
-tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/cs35l41_hda.patch" <<'EOF'
---- sound/pci/hda/cs35l41_hda.c.orig
-+++ sound/pci/hda/cs35l41_hda.c
-@@ -1244,6 +1244,10 @@
+tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/cs35l41_hda_property.patch" <<'EOF'
+--- sound/pci/hda/cs35l41_hda_property.c.orig
++++ sound/pci/hda/cs35l41_hda_property.c
+@@ -38,4 +38,8 @@
  		hw_cfg->bst_type = CS35L41_EXT_BOOST;
  		hw_cfg->gpio1.func = CS35l41_VSPK_SWITCH;
  		hw_cfg->gpio1.valid = true;
@@ -31,9 +31,7 @@ tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/cs35l41_hda.patch" <<
 +     hw_cfg->bst_type = CS35L41_EXT_BOOST;
 +     hw_cfg->gpio1.func = CS35l41_VSPK_SWITCH;
 +     hw_cfg->gpio1.valid = true;
- 	} else {
- 		/*
- 		 * Note: CLSA010(0/1) are special cases which use a slightly different design.
+ 	}
 EOF
 
 "${BIN_ABSPATH}/dkms-module_build.sh" "${KERNEL_MODULE_NAME}" "${DKMS_MODULE_VERSION}"


### PR DESCRIPTION
A change to the Linux kernel separated this portion of the file into cs35l41_hda_property.c. This commit reflects that change and should be compatible with Kernel 6.6.

Ref: https://github.com/torvalds/linux/commit/ef4ba63f12b03532378395a8611f2f6e22ece67b