### PR TITLE
updated os detection and some other minor changes

### DIFF
--- a/dkms-module_build.sh
+++ b/dkms-module_build.sh
@@ -18,11 +18,11 @@ dkms build -k "${KERNEL_VERSION}" -m "${KERNEL_MODULE_NAME}" -v "${DKMS_MODULE_V
 dkms install -k "${KERNEL_VERSION}" -m "${KERNEL_MODULE_NAME}" -v "${DKMS_MODULE_VERSION}" --force
 
 if dmesg | grep -q 'initramfs'; then
-  if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
+  if dist_test "debian"; then
     update-initramfs -u -k "${KERNEL_VERSION}"
-  elif grep -q "^ID=arch" /etc/os-release; then
+  elif dist_test "arch"; then
     mkinitcpio -P
-  elif grep -q "^ID=fedora" /etc/os-release; then
+  elif dist_test "fedora"; then
     sudo dracut --regenerate-all --force
   else
     echo "Update of initramfs not (yet) supported for your Linux distro. You might want to modify the distro-specific commands."

--- a/dkms-module_create.sh
+++ b/dkms-module_create.sh
@@ -15,10 +15,10 @@ DKMS_MODULE_VERSION="${2}"
 # check OS prerequisites --------------------------------------------------------------------------
 
 # perform OS-specific preparation steps
-if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
+if dist_test debian; then
   apt install build-essential dkms dwarves
 
-  if grep -q "^ID=ubuntu" /etc/os-release && [ -e "/usr/lib/modules/$(uname -r)/build" ]; then
+  if dist_test "ubuntu" && [ -e "/usr/lib/modules/$(uname -r)/build" ]; then
     # see https://askubuntu.com/questions/1348250/skipping-btf-generation-xxx-due-to-unavailability-of-vmlinux-on-ubuntu-21-04
     cp /sys/kernel/btf/vmlinux "/usr/lib/modules/$(uname -r)/build/"
   fi
@@ -27,7 +27,7 @@ else
 fi
 
 # install linux-headers package if not present 
-if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
+if dist_test "debian"; then
   HEADERS_PACKAGE_NAME="linux-headers-${KERNEL_VERSION}"
 
   if ! dpkg -l | grep -q $HEADERS_PACKAGE_NAME; then
@@ -37,9 +37,9 @@ if grep -qE "^ID(_LIKE)?=debian" /etc/os-release; then
     dpkg -l | grep -q $HEADERS_PACKAGE_NAME || \
        { echo "Could not install ${HEADERS_PACKAGE_NAME}. Try installing it manually."; exit 3; }
   fi
-elif grep -q "^ID=arch" /etc/os-release; then
+elif dist_test "arch"; then
   pacman -S pahole dkms base-devel linux-headers
-elif grep -q "^ID=fedora" /etc/os-release; then
+elif dist_test "fedora"; then
   dnf install dwarves dkms kernel-devel kernel-headers  
 else
   echo "Auto-installing kernel headers not (yet) supported for your Linux distro. You might want to modify the distro-specific commands."

--- a/setup_snd-hda-codec-realtek.sh
+++ b/setup_snd-hda-codec-realtek.sh
@@ -8,7 +8,7 @@ set -e
 BIN_ABSPATH="$(dirname "$(readlink -f "${0}")")"
 
 KERNEL_MODULE_NAME='snd-hda-codec-realtek'
-DKMS_MODULE_VERSION='0.1'
+DKMS_MODULE_VERSION='0.2'
 
 declare -a QUIRKS=( 'ALC245_FIXUP_CS35L41_SPI_2' 'ALC287_FIXUP_CS35L41_I2C_2' )
 
@@ -70,16 +70,19 @@ if [ $IS_AUTO_PATCH = true ]; then
     AUTO_PATCH_LINE="SND_PCI_QUIRK($ID1, $ID2, "'"'"$PRODUCT"'"'", $TARGET_QUIRK),"
   fi
 fi
-
+echo "AUTO PATCH LINE=$AUTO_PATCH_LINE"
+echo "Enter to continue, Ctrl-C to abort"
+read
 # create the patch file to apply to the source of the snd-hda-codec-realtek kernel module
 if [ $SOURCE_MINOR_VERSION = 8 ]; then
   tee "/usr/src/${KERNEL_MODULE_NAME}-${DKMS_MODULE_VERSION}/patch_realtek.patch" <<EOF
 --- sound/pci/hda/patch_realtek.c.orig
 +++ sound/pci/hda/patch_realtek.c
-@@ -9947,6 +9947,12 @@
+@@ -9947,6 +9947,13 @@
  	SND_PCI_QUIRK(0x103c, 0x89c6, "Zbook Fury 17 G9", ALC245_FIXUP_CS35L41_SPI_2_HP_GPIO_LED),
  	SND_PCI_QUIRK(0x103c, 0x89ca, "HP", ALC236_FIXUP_HP_MUTE_LED_MICMUTE_VREF),
  	SND_PCI_QUIRK(0x103c, 0x89d3, "HP EliteBook 645 G9 (MB 89D2)", ALC236_FIXUP_HP_MUTE_LED_MICMUTE_VREF),
++	 $AUTO_PATCH_LINE
 +  SND_PCI_QUIRK(0x103c, 0x8a06, "HP Dragonfly Folio 13.5 inch G3 2-in-1 Notebook PC", ALC245_FIXUP_CS35L41_SPI_2),
 +  SND_PCI_QUIRK(0x103c, 0x8a29, "HP Envy x360 15-ew0xxx", ALC287_FIXUP_CS35L41_I2C_2),
 +  SND_PCI_QUIRK(0x103c, 0x8a2c, "HP Envy 16-h0xxx", ALC287_FIXUP_CS35L41_I2C_2),


### PR DESCRIPTION
feel free to pick and choose.
1)    Changed OS detection to source /etc/os-release so quotes don't break it, and changed to partial string matches of ID and ID_LIKE.  This at least got it to detect Mint correctly as its ID_LIKE="debian ubuntu".  I don't think that'll cause problems for arch and fedora variants to test the same way.
2)    added the auto patch line to the 6.8 patch file
3)    added a pause to confirm that the auto detection worked before continuing